### PR TITLE
chore: not override rslib's rsbuild version when test plugins

### DIFF
--- a/tests/plugins.ts
+++ b/tests/plugins.ts
@@ -63,8 +63,6 @@ export async function test(options: RunOptions) {
 		let hasTestScript = false
 		await runInRepo({
 			...options,
-			// Only update the rsbuild version of direct dependencies, not indirect dependencies (such as the rsbuild version of rslib).
-			forceOverride: false,
 			repo,
 			branch: 'main',
 			beforeTest: async () => {
@@ -75,6 +73,9 @@ export async function test(options: RunOptions) {
 				if (playwright) {
 					await $`pnpm exec playwright install --with-deps`
 				}
+			},
+			overrides: {
+				'@rslib/core>@rsbuild/core': 'latest',
 			},
 			test: [
 				'build',

--- a/tests/plugins.ts
+++ b/tests/plugins.ts
@@ -75,6 +75,7 @@ export async function test(options: RunOptions) {
 				}
 			},
 			overrides: {
+				// not override rslib's rsbuild version
 				'@rslib/core>@rsbuild/core': 'latest',
 			},
 			test: [

--- a/tests/plugins.ts
+++ b/tests/plugins.ts
@@ -63,6 +63,8 @@ export async function test(options: RunOptions) {
 		let hasTestScript = false
 		await runInRepo({
 			...options,
+			// Only update the rsbuild version of direct dependencies, not indirect dependencies (such as the rsbuild version of rslib).
+			forceOverride: false,
 			repo,
 			branch: 'main',
 			beforeTest: async () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -51,8 +51,6 @@ export interface RepoOptions {
 	commit?: string
 	shallow?: boolean
 	overrides?: Overrides
-	// Whether to update all dependency versions through overrides instead of only updating those within the current project devDeps and deps
-	forceOverride?: boolean
 }
 
 export interface Overrides {

--- a/types.d.ts
+++ b/types.d.ts
@@ -51,6 +51,8 @@ export interface RepoOptions {
 	commit?: string
 	shallow?: boolean
 	overrides?: Overrides
+	// Whether to update all dependency versions through overrides instead of only updating those within the current project devDeps and deps
+	forceOverride?: boolean
 }
 
 export interface Overrides {


### PR DESCRIPTION
not override rslib's rsbuild version when test plugins.

https://github.com/web-infra-dev/rslib/issues/633