### PR TITLE
fix: peerDependencies validation error when using pnpm overrides

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -435,6 +435,15 @@ async function applyPackageOverrides(
 			...pkg.pnpm.overrides,
 			...overrides,
 		}
+
+		if (pkg.packageManager?.includes('pnpm@10')) {
+			// Temporary fix: peerDependencies validation error when using pnpm.overrides
+			// https://github.com/pnpm/pnpm/issues/8978
+			pkg.packageManager = 'pnpm@9.12.1'
+			if (pkg.engines?.pnpm) {
+				pkg.engines.pnpm = '>=9.0.0'
+			}
+		}
 	} else if (pm === 'yarn') {
 		if (!pkg.devDependencies) {
 			pkg.devDependencies = {}


### PR DESCRIPTION
Temporary fix peerDependencies validation error when using `pnpm.overrides` with `file:` protocol.

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/e63c375a-d9c0-4921-a808-5c52c644d2f7" />

https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/12802982226/job/35694933171


Reference: https://github.com/pnpm/pnpm/issues/8978 