### PR TITLE
ci(corepack): fix corepack key id mismatch

### DIFF
--- a/.github/actions/build-rsbuild/action.yaml
+++ b/.github/actions/build-rsbuild/action.yaml
@@ -29,6 +29,7 @@ runs:
     - shell: bash
       name: Install package manager
       run: |
+        npm install -g corepack@latest --force
         echo "Corepack version: $(corepack --version)"
         corepack enable
 


### PR DESCRIPTION
## Summary

Add `npm install -g corepack@latest --force` before `corepack enable` to fix corepack key id mismatch issue.

> `--force` to prevent windows install error

![image](https://github.com/user-attachments/assets/47a73c6c-240e-4c15-bf7b-1e23f8b1c54d)

## Related Links

https://github.com/nodejs/corepack/issues/612

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
