### PR TITLE
fix: revert pnpm overrides

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -436,15 +436,6 @@ async function applyPackageOverrides(
       ...pkg.pnpm.overrides,
       ...overrides,
     };
-
-    if (pkg.packageManager?.includes('pnpm@10')) {
-      // Temporary fix: peerDependencies validation error when using pnpm.overrides
-      // https://github.com/pnpm/pnpm/issues/8978
-      pkg.packageManager = 'pnpm@9.12.1';
-      if (pkg.engines?.pnpm) {
-        pkg.engines.pnpm = '>=9.0.0';
-      }
-    }
   } else if (pm === 'yarn') {
     if (!pkg.devDependencies) {
       pkg.devDependencies = {};


### PR DESCRIPTION
Since pnpm 10.2.0, `peerDependencies validation error when using pnpm.overrides` has been fixed.

## Related Links


https://github.com/pnpm/pnpm/issues/8978

https://github.com/rspack-contrib/rsbuild-ecosystem-ci/pull/11 