### PR TITLE
feat: add lynx-family/lynx-stack

### DIFF
--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -1,0 +1,13 @@
+import type { RunOptions } from '../types';
+import { runInRepo } from '../utils';
+
+export async function test(options: RunOptions) {
+  await runInRepo({
+    ...options,
+    repo: 'lynx-family/lynx-stack',
+    branch: process.env.LYNX_STACK_REF ?? 'main',
+    build: 'pnpm turbo build',
+    // TODO(colinaaa): enable Lynx for Web tests
+    test: 'test',
+  });
+}


### PR DESCRIPTION
We encountered a regression issue after upgrading Rsbuild (refer to https://github.com/web-infra-dev/rsbuild/pull/4909).

It would be highly beneficial to integrate lynx-family/lynx-stack tests into Rsbuild's EcoSystem CI.