### PR TITLE
ci: support ignore rstest snapshot changes

### DIFF
--- a/tests/rstest.ts
+++ b/tests/rstest.ts
@@ -6,6 +6,7 @@ export async function test(options: RunOptions) {
     ...options,
     repo: 'web-infra-dev/rstest',
     branch: process.env.RSTEST ?? 'main',
-    test: ['test'],
+    // ignore snapshot changes
+    test: ['test -u'],
   });
 }


### PR DESCRIPTION
Support ignoring rstest snapshot changes in rsbuild-ecosystem-ci, as some snapshot changes are expected.